### PR TITLE
Generalisations and additions to other cases (i.e., software/data carpentry material)

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-/usr/bin/python3 tools/poc.py 
+dirpo4md=$(dirname "$0")
+/usr/bin/python3 ${dirpo4md}/tools/poc.py

--- a/tools/createpot.py
+++ b/tools/createpot.py
@@ -78,12 +78,26 @@ class PFMMain:
 
             # print('%d: %s' % (line, mdstr), end="", flush=True)
             mdptype = self.mdparser.parse(mdstr)
-            if mdptype == 'blank':
-                continue
 
             mdp = MdPara()
             mdp.set_type(mdptype, mdstr)
             cline = line
+
+            # paragraph of text that's broken into multiple lines
+            if mdp.is_common():
+                while 1:
+                    mdstr = mdfile.readline()
+                    line += 1
+                    if not mdstr or self.mdparser.parse(mdstr) == 'blank':
+                        break
+                    if self.mdparser.parse(mdstr) == 'swclabel':
+                        line -= 1
+                        mdfile.seek(mdpos)
+                        break
+
+                    # print('%d: %s' % (line, mdstr), end="", flush=True)
+                    mdp.set_type(mdp.para_type(), mdp.para_msg() + mdstr)
+                    mdpos = mdfile.tell()
 
             # if Front matter yaml section starts # TODO join with codeblock?
             if mdp.is_yamlblock():

--- a/tools/createpot.py
+++ b/tools/createpot.py
@@ -83,6 +83,19 @@ class PFMMain:
             mdp.set_type(mdptype, mdstr)
             cline = line
 
+            # if Front matter yaml section starts # TODO join with codeblock?
+            if mdp.is_yamlblock():
+                while 1:
+                    mdstr = mdfile.readline()
+                    line += 1
+                    if not mdstr:
+                        break
+                    # print('%d: %s' % (line, mdstr), end="", flush=True)
+                    mdp.set_type(mdp.para_type(), mdp.para_msg() + mdstr)
+
+                    if self.mdparser.parse(mdstr) == 'yamlblock':
+                        break
+
             # if paragraph is common and is expectable to be a header
             # by looking forward the next line
             if mdp.is_headerline():

--- a/tools/createpot.py
+++ b/tools/createpot.py
@@ -19,8 +19,8 @@ class PFMMain:
 
         self.filelist = []
 
-        self.cwd = '{}/'.format(os.getcwd())
-        self.potpath = '{}po'.format(self.cwd)
+        self.cwd = os.getcwd()
+        self.potpath = os.path.join(self.cwd, 'po')
         self.potobj = None
 
         self.mdparser = MdParser()
@@ -31,36 +31,38 @@ class PFMMain:
             os.makedirs(self.potpath)
 
         # open POTFILES.in
-        outfile = open('{}/{}'.format(self.potpath, self.conf), 'w')
+        outfile = open(os.path.join(self.potpath, self.conf), 'w')
 
         print('Scanning markdown files ...')
         time.sleep(1)
 
         # list all md files on the document root
-        files = glob.glob(os.getcwd() + '/*.md')
+        files = glob.glob(os.path.join(self.cwd, '*.md'))
         files.sort()
 
         for file in files:
-            print('{} is found'.format(file.replace(self.cwd, '')))
-            outfile.write(file.replace(self.cwd, '') + '\n')
+            file = file.replace(self.cwd + os.sep, '')
+            print('{} is found'.format(file))
+            outfile.write(file + '\n')
 
-        dirs = os.listdir(os.getcwd())
+        dirs = os.listdir(self.cwd)
         dirs.sort()
 
         for dirn in dirs:
             if os.path.isdir(dirn):
-                mdfiles = glob.glob('{}{}/*.md'.format(self.cwd, dirn))
+                mdfiles = glob.glob(os.path.join(self.cwd, dirn, '*.md'))
                 mdfiles.sort()
 
                 for mdfile in mdfiles:
-                    print('{} is found'.format(mdfile.replace(self.cwd, '')))
-                    outfile.write(mdfile.replace(self.cwd, '') + '\n')
+                    mdfile = mdfile.replace(self.cwd + os.sep, '')
+                    print('{} is found'.format(mdfile))
+                    outfile.write(mdfile + '\n')
 
         print('File list is saved to po/POTFILES.in\n')
         outfile.close()
 
     def parse_md(self, filename):
-        mdfile = open('{}/{}'.format(os.getcwd(), filename), 'r')
+        mdfile = open(os.path.join(os.getcwd(), filename), 'r')
         mdobj = MdFile(filename)
 
         print('Extracting messages from {} ... '.format(filename))
@@ -175,7 +177,7 @@ class PFMMain:
         # init pot
         self.potobj = PoTemplate()
         self.potobj.set_filename(dstr)
-        self.potobj.set_project_title(os.getcwd().split('/')[-1])
+        self.potobj.set_project_title(os.path.split(self.cwd)[-1])
         self.potobj.set_report_bug(
             'https://github.com/haiwen/seafile-docs/issues')
 
@@ -184,7 +186,7 @@ class PFMMain:
         self.scan_md()
 
         # open POTFILES.in
-        dfl = open('{}/{}'.format(self.potpath, self.conf), 'r')
+        dfl = open(os.path.join(self.potpath, self.conf), 'r')
         dname = ''
 
         while 1:
@@ -195,7 +197,7 @@ class PFMMain:
 
             # create pot file per directory
             filename = filename[:-1]
-            dstr = '/' in filename and filename.split('/')[0] or 'doc-root'
+            dstr = os.sep in filename and filename.split(os.sep)[0] or 'doc-root'
 
             # if directory has changed
             if dname != dstr:

--- a/tools/pfm/fileobj/mdpara.py
+++ b/tools/pfm/fileobj/mdpara.py
@@ -27,6 +27,9 @@ class MdPara:
     def para_msg(self):
         return self.paramsg
 
+    def is_yamlblock(self):
+        return self.check_type('yamlblock')
+
     def is_header(self):
         return self.check_type('header')
 

--- a/tools/pfm/fileobj/mdpara.py
+++ b/tools/pfm/fileobj/mdpara.py
@@ -66,5 +66,8 @@ class MdPara:
     def is_rule(self):
         return self.check_type('hr')
 
+    def is_swclabel(self):
+        return self.check_type('swclabel')
+
     def is_blank(self):
         return self.check_type('blank')

--- a/tools/pfm/fileobj/pot.py
+++ b/tools/pfm/fileobj/pot.py
@@ -129,9 +129,9 @@ class PoTemplate:
         del tmdp_list
 
     def export(self):
-        fpath = '{}/{}/{}.pot'.format(os.getcwd(), 'po', self.filename)
+        fpath = os.path.join(os.getcwd(), 'po', self.filename + '.pot')
         print('Creating {} ... '.format(
-            fpath.replace(os.getcwd() + '/', '')), end='')
+            fpath.replace(os.getcwd() + os.sep, '')), end='')
         self.fo = open(fpath, 'w')
 
         self.prepare_header()

--- a/tools/pfm/fileobj/pot.py
+++ b/tools/pfm/fileobj/pot.py
@@ -171,6 +171,9 @@ class PoTemplate:
                 elif pobj.is_codeblock():
                     self.fo.write('# code block\n')
 
+                elif pobj.is_yamlblock():
+                    self.fo.write('# Front Matter\n')
+
                 elif pobj.is_tagopen():
                     self.fo.write('# inline html\n')
 

--- a/tools/pfm/fileobj/pot.py
+++ b/tools/pfm/fileobj/pot.py
@@ -183,6 +183,8 @@ class PoTemplate:
                 elif pobj.is_rule():
                     self.fo.write(
                         '# horizontal rule. just copy and paste from the msgid')
+                elif pobj.is_swclabel():
+                    self.fo.write('# SC/DC Template label\n')
 
                 # message id
                 self.fo.write('msgid "')

--- a/tools/pfm/mdparser.py
+++ b/tools/pfm/mdparser.py
@@ -5,6 +5,7 @@ import re
 
 class MdParser:
     def __init__(self):
+        self.yaml = re.compile(r'(-){3}')
         self.hc = re.compile(r'(^[\s\S]+\n(-[-]+|=[=]+)|' +
                              r'^([#]{1,6})\s[\s\S]+(\s\3)?)')
         self.hlc = re.compile(r'^(-[-]+|=[=]+)\n?$')
@@ -21,7 +22,10 @@ class MdParser:
 
 
     def parse(self, mstr):
-        if self.bqc.match(mstr):
+        if self.yaml.match(mstr):
+            return 'yamlblock'
+
+        elif self.bqc.match(mstr):
             return 'blockquote'
 
         elif self.ulc.match(mstr):

--- a/tools/pfm/mdparser.py
+++ b/tools/pfm/mdparser.py
@@ -19,10 +19,14 @@ class MdParser:
         self.blc = re.compile(r'^\s*\n$')
         self.wtoc = re.compile(r'^\{\|(\s[a-z]+\=\"[0-9A-Za-z]+\")+\n$')
         self.wtcc = re.compile(r'^\|\}\n$')
+        self.swclabel = re.compile(r'[\>]*[\s]*\{:\s\.[\w]+\}\n$')
 
     def parse(self, mstr):
         if self.yaml.match(mstr):
             return 'yamlblock'
+
+        elif self.swclabel.match(mstr):
+            return 'swclabel'
 
         elif self.bqc.match(mstr):
             return 'blockquote'

--- a/tools/pfm/mdparser.py
+++ b/tools/pfm/mdparser.py
@@ -13,13 +13,12 @@ class MdParser:
         self.ulc = re.compile(r"^([\s]*[\*\+\-]\s)[\S\s]+$")
         self.olc = re.compile(r'^[1-9][0-9]*\.\s[\S\s]+$')
         self.hrc = re.compile(r'^([\*\-_]+|([\*\-_]\s){3,})$')
-        self.cbc = re.compile(r'^([\s]*```)[\s\S]+$')
+        self.cbc = re.compile(r'^([\s]*```)[\s\S]+$|^(~){3}')
         self.toc = re.compile(r'^<[\w]+>\n$')
         self.tcc = re.compile(r'^</[\w]+>\n$')
         self.blc = re.compile(r'^\s*\n$')
         self.wtoc = re.compile(r'^\{\|(\s[a-z]+\=\"[0-9A-Za-z]+\")+\n$')
         self.wtcc = re.compile(r'^\|\}\n$')
-
 
     def parse(self, mstr):
         if self.yaml.match(mstr):

--- a/tools/pfm/poparser.py
+++ b/tools/pfm/poparser.py
@@ -5,7 +5,7 @@ import re
 
 class PoParser:
     def __init__(self):
-        self.dsc = re.compile(r'^#\s[a-zA-Z0-9\-\._<>@,\s]*$')
+        self.dsc = re.compile(r'^#\s[\wa-zA-Z0-9\-\._<>@,\s]*$')
         self.phc = re.compile(
             r'^\"([A-Z][A-Za-z0-9]+)(\-[A-Z][A-Za-z0-9]+)+' +
             r':\s[a-zA-Z0-9@<>:;=/\.\-\+\s]+\\n\"')

--- a/tools/poc.py
+++ b/tools/poc.py
@@ -52,8 +52,8 @@ class LangTeamMissingException(Exception):
 
 class PoCompiler:
     def __init__(self):
-        self.sourcedir = '{}/po'.format(os.getcwd())
-        self.outputdir = '{}/locale'.format(os.getcwd())
+        self.sourcedir = os.path.join(os.getcwd(), 'po')
+        self.outputdir = os.path.join(os.getcwd(), 'locale')
         self.outfile = None
 
         self.last_trans_name = []
@@ -239,14 +239,14 @@ class PoCompiler:
         mdlist = self.pofile.msg_object()
         for mdfn in sorted(mdlist.keys()):
             mdfo = mdlist.get(mdfn)
-            tpath = '{}/{}/{}'.format(self.outputdir, self.clocale,
-                                      mdfn.split('/')[0])
+            tpath = os.path.join(self.outputdir, self.clocale,
+                                      mdfn.split(os.sep)[0])
             if not os.path.exists(tpath) and '/' in mdfn:
                 os.makedirs(tpath, 0o755)
 
             # writeout to md
-            self.outfile = open(
-                '{}/{}/{}'.format(self.outputdir, self.clocale, mdfn), 'w')
+            self.outfile = open(os.path.join(
+                self.outputdir, self.clocale, mdfn), 'w')
             print('Writing {} ... '.format(self.outfile.name), end='')
 
             # cln : current line number
@@ -290,11 +290,11 @@ class PoCompiler:
             print('OK')
 
     def run(self):
-        cll = open('{}/LINGUAS'.format(self.sourcedir), 'r').readline()
+        cll = open(os.path.join(self.sourcedir, 'LINGUAS'), 'r').readline()
         self.langlist = cll[:-1].split(' ')
 
         for lang in self.langlist:
-            polist = glob.glob('{}/*.{}.po'.format(self.sourcedir, lang))
+            polist = glob.glob(os.path.join(self.sourcedir, '*.{}.po'.format(lang)))
             if len(polist) != 0:
                 print('Compiling *.{}.po ...'.format(lang))
             self.clocale = lang

--- a/tools/poc.py
+++ b/tools/poc.py
@@ -6,6 +6,7 @@ import glob
 import os
 import re
 from datetime import datetime
+import unicodedata as ud
 
 from dateutil.tz import tzlocal
 from pfm.fileobj.mdfile import MdFile
@@ -65,7 +66,7 @@ class PoCompiler:
         self.poparser = PoParser()
         self.crpt = r'^# This file is distributed under the same license as ' \
                     r'the [a-zA-Z0-9\-\.\_]+ package\.\n?$'
-        self.creditpt = '^#\s([A-Z][a-z\W]+)([\-\s][A-Z][a-z\W]+)+' \
+        self.creditpt = '^#\s([\wA-Z][\wa-z\W]+)([\-\s][\wA-Z][\wa-z\W]+)+' \
                         '\s\<[a-zA-Z0-9\.\-_]+\@'\
                         '[a-zA-Z0-9\-_]+(\.[a-zA-Z0-9\-_]+)+\>' \
                         '(,\s([1-2][0-9]{3})(\-([1-2][0-9]{3}))?)+\.\n?$'
@@ -89,7 +90,9 @@ class PoCompiler:
         exist_credit = False
 
         while 1:
-            poline = self.f.readline()[:-1]
+            # How to include names with strange characters
+            # https://stackoverflow.com/questions/18663644/how-to-account-for-accent-characters-for-regex-in-python
+            poline = ud.normalize('NFC', self.f.readline()[:-1])
             pt = self.poparser.parse(poline)
 
             # end of verification

--- a/tools/poc.py
+++ b/tools/poc.py
@@ -271,18 +271,15 @@ class PoCompiler:
                         lndf -= 1
 
                 pomobj = pomarr.get(poln)
+                lim = pomobj.msgid().count('\\n') - pomobj.msgid().count('\\\\n')
                 if len(pomobj.msgstr()) == 0:
-                    lim = pomobj.msgid().count('\\n')
-                    self.outfile.write(
-                        pomobj.msgid()
-                              .replace('\\n', '\n')
-                              .replace('\\"', '\"')
-                              .replace('\\\\', '\\'))
+                    msg_to_file = pomobj.msgid()
                 else:
-                    lim = pomobj.msgstr().count('\\n')
-                    self.outfile.write(
-                        pomobj.msgstr()
+                    msg_to_file = pomobj.msgstr()
+                self.outfile.write(
+                    msg_to_file
                               .replace('\\n', '\n')
+                              .replace('\\\n', '\\n') # in case there's a directory as c:\Documents\nelle
                               .replace('\\"', '\"')
                               .replace('\\\\', '\\'))
 

--- a/tools/updatepo.py
+++ b/tools/updatepo.py
@@ -8,9 +8,9 @@ import os
 
 class UpdatePo:
     def __init__(self):
-        self.popath = '{}/po'.format(os.getcwd())
+        self.popath = os.path.join(os.getcwd(), 'po')
         self.cmd_prefix = 'msgmerge -vU '
-        self.cmd_pstfix = ' > /dev/null'
+        self.cmd_pstfix = ' > /dev/null' #FIXME: to use os.devnull?
         
         self.potlist = []
         self.polist = []
@@ -20,11 +20,12 @@ class UpdatePo:
         return '{} {} {}'.format(self.cmd_prefix, argv, self.cmd_pstfix)
 
     def run(self):
-        self.potlist = glob.glob('{}/*.pot'.format(self.popath))
+        self.potlist = glob.glob(os.path.join(self.popath, '*.pot'))
 
         for pot in self.potlist:
-            fn = pot.split('/')[-1].split('.')[0]
-            self.polist = glob.glob('{}/{}.*.po'.format(self.popath, fn))
+            fn = os.path.split(pot)[-1].split('.')[0]
+            fn += '.*.po'
+            self.polist = glob.glob(os.path.join(self.popath, fn))
 
             for po in self.polist:
                 print('Updating {} ...'.format(po))

--- a/update.sh
+++ b/update.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-/usr/bin/python3 tools/createpot.py
-/usr/bin/python3 tools/updatepo.py
+dirpo4md=$(dirname "$0")
+/usr/bin/python3 ${dirpo4md}/tools/createpot.py
+/usr/bin/python3 ${dirpo4md}/tools/updatepo.py


### PR DESCRIPTION
I don't know how useful this is for gitbook, but these changes are really useful to the software and data carpentry materials ([swc](https://software-carpentry.org/lessons/), [dc](http://www.datacarpentry.org/lessons/)) which uses jekyll to render the website ([front matter](https://jekyllrb.com/docs/frontmatter/) - 9234e30)).

Other changes:
- I've also fixed a problem that arises when the translator name has accentuated characters. (49c1947)
- Generalisation of the scripts to run from anywhere (f0a7147)
- Don't create new lines when in the text contains something like a Windows directory, e.g., `foo\name` (7cf6ddf)
- Changed all path creations to use `os.path.join()` (15ae1b3)
- I've also changed that lines were created as single entries to translate, as that makes it very hard when text has been broken into lines into no meaningful blocks. I'm sure there's a better way to do so than what I've done (37f3b8d)

I don't know how many things I may have broken with this changes. I may start adding tests in the future.

@darkcircle Thanks a lot for all this code!! It's really useful!!